### PR TITLE
fix: Central Composite Design crashing with categorical parameters

### DIFF
--- a/optimeo/doe.py
+++ b/optimeo/doe.py
@@ -472,7 +472,8 @@ class DesignOfExperiments:
             else:
                 self.design = build.box_behnken(d=pars)
         elif self.type == 'Central Composite':
-            self.design = build.central_composite(pars, 
+            pars_list = {k: v.tolist() if hasattr(v, 'tolist') else list(v) for k, v in pars.items()}
+            self.design = build.central_composite(pars_list,
                                                   center=self.center,
                                                   alpha=self.alpha,
                                                   face=self.face)
@@ -480,9 +481,11 @@ class DesignOfExperiments:
             raise ValueError("Unknown design type. Must be one of: 'Full Factorial', 'Sobol sequence', 'Fractional Factorial', 'Definitive Screening', 'Space Filling Latin Hypercube', 'Randomized Latin Hypercube', 'Optimal', 'Plackett-Burman', 'Box-Behnken' or 'Central Composite'.")
 
         for par in self.parameters:
-            if par['type'] == "Categorical" and self.type != 'Sobol sequence':
+            if par['type'].lower() == "categorical" and self.type != 'Sobol sequence':
                 vals = self._design[par['name']].to_numpy()
-                self.design[par['name']] = par['encoder'].inverse_transform([int(v) for v in vals])
+                n_classes = len(par['encoder'].classes_)
+                clipped = [int(np.clip(np.round(v), 0, n_classes - 1)) for v in vals]
+                self.design[par['name']] = par['encoder'].inverse_transform(clipped)
 
         # randomize the run order
         self.design['run_order'] = np.arange(len(self._design)) + 1

--- a/pages/1_1._Design_Of_Experiments.py
+++ b/pages/1_1._Design_Of_Experiments.py
@@ -342,7 +342,8 @@ elif design_type=='Central Composite':
     #     alpha = 'r'
     # change parameter values to list
     for par in range(Npars):
-        parameters[par]['values'] = parameters[par]['values'].tolist()
+        if not isinstance(parameters[par]['values'], list):
+            parameters[par]['values'] = parameters[par]['values'].tolist()
 
 doe = DesignOfExperiments(
     type                = design_type,

--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -13,7 +13,8 @@ from optimeo.doe import DesignOfExperiments
 sample_parameters = [
         {'name': 'Temperature', 'type': 'integer', 'values': [20, 30, 40]},
         {'name': 'Pressure', 'type': 'float', 'values': [1, 2, 3]},
-        {'name': 'Catalyst', 'type': 'categorical', 'values': ['A', 'B', 'C']}
+        {'name': 'Catalyst', 'type': 'categorical', 'values': ['A', 'B', 'C']},
+        {'name': 'Speed', 'type': 'categorical', 'values': [100, 200, 300]}
     ]
 
 # Sample design types for testing
@@ -44,6 +45,23 @@ def test_initialization():
         assert isinstance(doe.design, pd.DataFrame)
         assert not doe.design.empty
         assert len(fig) > 0
+
+def test_central_composite_numeric():
+    """Test Central Composite with numeric parameters only."""
+    doe = DesignOfExperiments(type="Central Composite", parameters=sample_parameters)
+    assert isinstance(doe.design, pd.DataFrame)
+    assert not doe.design.empty
+
+def test_central_composite_with_categorical():
+    """Test Central Composite with a categorical parameter — axial star points must be clipped to valid labels."""
+    params = [
+        {'name': 'Temperature', 'type': 'float', 'values': [20, 40]},
+        {'name': 'Catalyst', 'type': 'categorical', 'values': ['A', 'B', 'C']},
+    ]
+    doe = DesignOfExperiments(type="Central Composite", parameters=params)
+    assert isinstance(doe.design, pd.DataFrame)
+    assert not doe.design.empty
+    assert set(doe.design['Catalyst']).issubset({'A', 'B', 'C'})
 
 def test_invalid_design_type():
     """Test if an invalid design type raises an error."""


### PR DESCRIPTION
**Bug**

I tried using a categorical parameter with Central Composite Design and i got three errors one after another:

1. `.tolist()` was called on something that was already a list (categorical values come in as plain Python lists, not numpy arrays)
2. `doepy` internally calls `.append()` on the factor values, which breaks on numpy arrays  and categorical values had been converted to numpy arrays by `LabelEncoder` before being passed in
3. CCD generates star points that go outside the encoded range, so when trying to decode `[-1, 3]` back to labels like `A/B/C`, sklearn's `inverse_transform` throws a fit because it's never seen those values

On top of that, there was a quiet bug where the decode step was never running at all for lowercase `"categorical"` types, the check was hardcoded as `== "Categorical"` so it never matched.

**To reproduce**

Open the DoE page, switch the design to Central Composite. Then add a parameter, set its type to Categorical, and change the default `A,B` values to something with three or more levels like `A,B,C` or `1,2,3`.  and hit generate

**What I changed**

- Added an `isinstance` check before calling `.tolist()` so it only runs when the values are actually a numpy array
- Convert the `pars` dict values to plain Python lists right before passing to `doepy`
- Clip any out-of-range star point values to `[0, n_classes - 1]` before decoding, so they fall back to the nearest valid label instead of crashing
- Fixed `== "Categorical"` to use `.lower()` so it matches regardless of how the type was entered

**Tests**

Added two tests to `test_doe.py` and extended `sample_parameters` with a `Speed` categorical parameter that uses numbers as values (instead of strings) to cover that edge case:

- `test_central_composite_numeric` just making sure CCD still works fine with numeric parameters
- `test_central_composite_with_categorical` runs CCD with a categorical parameter and checks that every value in the output column is one of the original labels

<img width="929" height="407" alt="image" src="https://github.com/user-attachments/assets/74ed4733-be3b-47db-8ea1-c8497cb6e9f5" />
